### PR TITLE
Fix bug with renumbering posts after merging discussions

### DIFF
--- a/src/Api/Commands/MergeDiscussionHandler.php
+++ b/src/Api/Commands/MergeDiscussionHandler.php
@@ -88,6 +88,9 @@ class MergeDiscussionHandler
             $discussion->posts[$i] = $post;
         });
 
+        // @see https://github.com/FriendsOfFlarum/merge-discussions/issues/5
+        $discussion->setRelation('posts', $discussion->posts->sortByDesc('number'));
+
         $discussion->post_number_index = $number;
 
         if ($command->merge) {


### PR DESCRIPTION
This change ensures that renumbering is preformed from the end (newest posts first). In this way we can avoid situation, when some post needs to use for example `3` as `number`, while this value is still reserved by old post (which is nor yet renumbered).

fix #5