### PR TITLE
Fix posts number

### DIFF
--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -27,6 +27,7 @@ fof-merge-discussions:
       merging_failed: Failed to merge discussions.
       updating_failed: Failed to update discussion details.
       deleting_failed: Failed to delete empty discussions.
+      fixing_posts_number_failed: Failed to fix posts numbers.
 
   ref:
     merge: Merge

--- a/src/Api/Commands/MergeDiscussionHandler.php
+++ b/src/Api/Commands/MergeDiscussionHandler.php
@@ -167,7 +167,7 @@ class MergeDiscussionHandler
             $discussion->posts[$i] = $post;
         });
 
-        $discussion->setRelation('posts', $discussion->posts->sortByDesc('number'));
+        $discussion->setRelation('posts', $discussion->posts->sortBy('number'));
         $discussion->post_number_index = $number;
 
         resolve('db.connection')->transaction(function () use ($discussion) {


### PR DESCRIPTION
**Case**
discussion A have 3 posts with numbers : 1,2,3
discussion B have 2 posts with numbers : 1,2
with time order A1,A2,A3,B1,B2

then you "Delete Forever" post 2 at discussion A

discussion A have 2 posts with numbers : 1,3
discussion B have 2 posts with numbers : 1,2
with time order A1,A3,B1,B2

when you merge discussion B to A it "renumber"
B2 => A4
B1 => A3
A3 => A2
A1 => A1

but second sql update (B1 => A3) throws error that unique index A3 already exist

**Changes proposed in this pull request:**
we will fix posts number on target discussion before merging