### PR TITLE
Dk/redirections

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -50,4 +50,7 @@ return [
 
     (new Extend\Notification())
         ->type(Notification\DiscussionMergedBlueprint::class, DiscussionSerializer::class, ['alert', 'email']),
+
+    (new Extend\Middleware('forum'))
+        ->insertBefore(HandleErrors::class, Middleware\Redirection::class),
 ];

--- a/migrations/2022_01_04_000000_create_redirections_table.php
+++ b/migrations/2022_01_04_000000_create_redirections_table.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of fof/merge-discussion.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Flarum\Database\Migration;
+use Flarum\Discussion\Discussion;
+use Illuminate\Database\Schema\Blueprint;
+
+return Migration::createTable('fof_merge_discussions_redirections', function (Blueprint $table) {
+    $table->increments('id');
+    $table->foreignIdFor(Discussion::class, 'request_discussion_id');
+    $table->foreignIdFor(Discussion::class, 'to_discussion_id');
+    $table->unsignedInteger('http_code');
+    $table->timestamp('created_at');
+});

--- a/migrations/2022_01_04_000000_create_redirections_table.php
+++ b/migrations/2022_01_04_000000_create_redirections_table.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of fof/merge-discussion.
+ * This file is part of fof/merge-discussions.
  *
  * Copyright (c) FriendsOfFlarum.
  *

--- a/src/Api/Commands/MergeDiscussionHandler.php
+++ b/src/Api/Commands/MergeDiscussionHandler.php
@@ -20,7 +20,6 @@ use FoF\MergeDiscussions\Events\DiscussionWasMerged;
 use FoF\MergeDiscussions\Models\Redirection;
 use FoF\MergeDiscussions\Validators\MergeDiscussionValidator;
 use Illuminate\Events\Dispatcher;
-use Illuminate\Support\Arr;
 use Throwable;
 
 class MergeDiscussionHandler
@@ -90,10 +89,11 @@ class MergeDiscussionHandler
 
                     $post->number = $number;
                     $post->discussion_id = $discussion->id;
+
                     return $post;
                 })
         );
-        
+
         $discussion->post_number_index = $number;
 
         if ($command->merge) {

--- a/src/Api/Commands/MergeDiscussionHandler.php
+++ b/src/Api/Commands/MergeDiscussionHandler.php
@@ -81,16 +81,19 @@ class MergeDiscussionHandler
 
         $discussion->setRelation(
             'posts',
-            $posts
-                ->merge($discussion->posts)
+            $discussion
+                ->posts
+                ->merge($posts)
                 ->sortBy('created_at')
                 ->map(function (Post $post) use (&$number, $discussion) {
                     $number++;
 
                     $post->number = $number;
                     $post->discussion_id = $discussion->id;
+                    return $post;
                 })
         );
+        
         $discussion->post_number_index = $number;
 
         if ($command->merge) {
@@ -125,7 +128,7 @@ class MergeDiscussionHandler
             });
 
             $this->events->dispatch(
-                new DiscussionWasMerged($command->actor, $posts->toArray(), $discussion, $discussions->toArray())
+                new DiscussionWasMerged($command->actor, $posts, $discussion, $discussions)
             );
         }
 

--- a/src/Api/Commands/MergeDiscussionHandler.php
+++ b/src/Api/Commands/MergeDiscussionHandler.php
@@ -74,7 +74,7 @@ class MergeDiscussionHandler
         $posts = $discussions->pluck('posts')->flatten(1);
 
         $this->validator->assertValid([
-            'posts' => $posts,
+            'posts' => $posts->toArray(),
         ]);
 
         $number = 0;
@@ -125,7 +125,7 @@ class MergeDiscussionHandler
             });
 
             $this->events->dispatch(
-                new DiscussionWasMerged($command->actor, $posts->toArray(), $discussion, $discussions)
+                new DiscussionWasMerged($command->actor, $posts->toArray(), $discussion, $discussions->toArray())
             );
         }
 

--- a/src/Api/Commands/MergeDiscussionHandler.php
+++ b/src/Api/Commands/MergeDiscussionHandler.php
@@ -20,8 +20,8 @@ use FoF\MergeDiscussions\Events\DiscussionWasMerged;
 use FoF\MergeDiscussions\Models\Redirection;
 use FoF\MergeDiscussions\Validators\MergeDiscussionValidator;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Support\Collection as SupportCollection;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Collection as SupportCollection;
 use Throwable;
 
 class MergeDiscussionHandler

--- a/src/Events/DiscussionWasMerged.php
+++ b/src/Events/DiscussionWasMerged.php
@@ -14,6 +14,7 @@ namespace FoF\MergeDiscussions\Events;
 use Flarum\Discussion\Discussion;
 use Flarum\Post\Post;
 use Flarum\User\User;
+use Illuminate\Support\Collection;
 
 class DiscussionWasMerged
 {
@@ -23,7 +24,7 @@ class DiscussionWasMerged
     public $actor;
 
     /**
-     * @var Post[]
+     * @var Post[]|Collection
      */
     public $posts;
 
@@ -33,11 +34,11 @@ class DiscussionWasMerged
     public $discussion;
 
     /**
-     * @var Discussion[] Discussion
+     * @var Discussion[]|Collection Discussion
      */
     public $mergedDiscussions;
 
-    public function __construct(User $actor, $posts, $discussion, $mergedDiscussions)
+    public function __construct(User $actor, Collection $posts, Discussion $discussion, Collection $mergedDiscussions)
     {
         $this->actor = $actor;
         $this->posts = $posts;

--- a/src/Jobs/SendNotificationWhenDiscussionIsMerged.php
+++ b/src/Jobs/SendNotificationWhenDiscussionIsMerged.php
@@ -18,6 +18,7 @@ use FoF\MergeDiscussions\Notification\DiscussionMergedBlueprint;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
 
 class SendNotificationWhenDiscussionIsMerged implements ShouldQueue
 {
@@ -39,7 +40,7 @@ class SendNotificationWhenDiscussionIsMerged implements ShouldQueue
      */
     protected $mergedDiscussions;
 
-    public function __construct(Discussion $discussion, array $mergedDiscussions, User $actor)
+    public function __construct(Discussion $discussion, Collection $mergedDiscussions, User $actor)
     {
         $this->discussion = $discussion;
         $this->mergedDiscussions = $mergedDiscussions;

--- a/src/Middleware/Redirection.php
+++ b/src/Middleware/Redirection.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/merge-discussions.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\MergeDiscussions\Middleware;
 
 use FastRoute\Dispatcher\GroupCountBased;
@@ -43,7 +52,7 @@ class Redirection implements MiddlewareInterface
 
             $redirect = Redirect::request($id);
 
-            if (! $redirect) {
+            if (!$redirect) {
                 return $response;
             }
 

--- a/src/Middleware/Redirection.php
+++ b/src/Middleware/Redirection.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace FoF\MergeDiscussions\Middleware;
+
+use FastRoute\Dispatcher\GroupCountBased;
+use Flarum\Http\RouteCollection;
+use FoF\MergeDiscussions\Models\Redirection as Redirect;
+use Illuminate\Support\Arr;
+use Laminas\Diactoros\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class Redirection implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $response = $handler->handle($request);
+
+        // In case of a valid 404 response start identifying whether we need to redirect.
+        if ($response instanceof Response
+            && $response->getStatusCode() === 404) {
+
+            /** @var RouteCollection $routes */
+            $routes = resolve('flarum.forum.routes');
+
+            $dispatcher = $this->getDispatcher($routes);
+
+            // Use the route dispatcher to identify routing information.
+            $route = $dispatcher->dispatch(
+                $request->getMethod(),
+                $request->getUri()->getPath() ?: '/'
+            );
+
+            // Identify the requested route.
+            if (Arr::get($route, '1.name') !== 'discussion') {
+                return $response;
+            }
+
+            // Identify the requested discussion Id.
+            $id = Arr::get($route, '2.id');
+
+            $redirect = Redirect::request($id);
+
+            if (! $redirect) {
+                return $response;
+            }
+
+            // Retrieve original URI.
+            // Patch this URI with the new discussion to forward to.
+            $uri = $request
+                ->getUri()
+                ->withPath($routes->getPath('discussion', ['id' => $redirect->to_discussion_id]));
+
+            // Send a redirect response to the client with the predefined http code.
+            return new Response\RedirectResponse(
+                $uri,
+                $redirect->http_code
+            );
+        }
+
+        return $response;
+    }
+
+    protected function getDispatcher(RouteCollection $routes): GroupCountBased
+    {
+        return new GroupCountBased($routes->getRouteData());
+    }
+}

--- a/src/Models/Redirection.php
+++ b/src/Models/Redirection.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace FoF\MergeDiscussions\Models;
+
+use Carbon\Carbon;
+use Flarum\Database\AbstractModel;
+use Flarum\Discussion\Discussion;
+
+/**
+ * @property int $id
+ * @property int $request_discussion_id
+ * @property int $to_discussion_id
+ * @property int $http_code
+ * @property Carbon $created_at
+ */
+class Redirection extends AbstractModel
+{
+    public $timestamps = true;
+
+    protected $table = 'fof_merge_discussions_redirections';
+
+    public static function build(Discussion $request, Discussion $target, int $httpCode = 301): self
+    {
+        $redirection = new self;
+        $redirection->request_discussion_id = $request->id;
+        $redirection->to_discussion_id = $target->id;
+        $redirection->http_code = $httpCode;
+
+        $redirection->save();
+
+        return $redirection;
+    }
+
+    public static function request($id): ?self
+    {
+        return self::query()
+            ->where('request_discussion_id', $id)
+            ->first();
+    }
+
+    public function getUpdatedAtColumn()
+    {
+        return null;
+    }
+}

--- a/src/Models/Redirection.php
+++ b/src/Models/Redirection.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/merge-discussions.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\MergeDiscussions\Models;
 
 use Carbon\Carbon;
@@ -7,10 +16,10 @@ use Flarum\Database\AbstractModel;
 use Flarum\Discussion\Discussion;
 
 /**
- * @property int $id
- * @property int $request_discussion_id
- * @property int $to_discussion_id
- * @property int $http_code
+ * @property int    $id
+ * @property int    $request_discussion_id
+ * @property int    $to_discussion_id
+ * @property int    $http_code
  * @property Carbon $created_at
  */
 class Redirection extends AbstractModel
@@ -21,7 +30,7 @@ class Redirection extends AbstractModel
 
     public static function build(Discussion $request, Discussion $target, int $httpCode = 301): self
     {
-        $redirection = new self;
+        $redirection = new self();
         $redirection->request_discussion_id = $request->id;
         $redirection->to_discussion_id = $target->id;
         $redirection->http_code = $httpCode;

--- a/src/Posts/DiscussionMergePost.php
+++ b/src/Posts/DiscussionMergePost.php
@@ -11,10 +11,10 @@
 
 namespace FoF\MergeDiscussions\Posts;
 
-use Flarum\Discussion\Discussion;
 use Flarum\Post\AbstractEventPost;
 use Flarum\Post\MergeableInterface;
 use Flarum\Post\Post;
+use Illuminate\Support\Collection;
 
 class DiscussionMergePost extends AbstractEventPost implements MergeableInterface
 {
@@ -40,17 +40,7 @@ class DiscussionMergePost extends AbstractEventPost implements MergeableInterfac
         return $this;
     }
 
-    /**
-     * Create a new instance in reply to a discussion.
-     *
-     * @param int          $discussionId
-     * @param int          $userId
-     * @param int          $postsCount
-     * @param Discussion[] $mergedDiscussions
-     *
-     * @return static
-     */
-    public static function reply($discussionId, $userId, $postsCount, $mergedDiscussions)
+    public static function reply(int $discussionId, int $userId, int $postsCount, Collection $mergedDiscussions): self
     {
         $post = new static();
 
@@ -62,19 +52,11 @@ class DiscussionMergePost extends AbstractEventPost implements MergeableInterfac
         return $post;
     }
 
-    /**
-     * Build the content attribute.
-     *
-     * @param int          $postsCount  Number of posts merged
-     * @param Discussion[] $discussions Merged discussions
-     *
-     * @return array
-     */
-    public static function buildContent($postsCount, $discussions)
+    public static function buildContent(int $postsCount, Collection $discussions): array
     {
         return [
             'count'  => (int) $postsCount,
-            'titles' => collect($discussions)->map(function ($d) {
+            'titles' => $discussions->map(function ($d) {
                 return $d->title;
             }),
         ];


### PR DESCRIPTION
This adds automatic redirection using a middleware to merge-discussions so that whenever merged discussions are deleted, hitting them won't cause a 404 but a 301 redirection to the new discussion. This change introduces a new migration, model and middleware. I've also patched the merge discussion handler to be somewhat cleaner and more performant.

fixes #21