### PR TITLE
fix: abstract `excerpt` method not implemented in notification component

### DIFF
--- a/js/src/forum/components/DiscussionMergedNotification.js
+++ b/js/src/forum/components/DiscussionMergedNotification.js
@@ -24,4 +24,8 @@ export default class DiscussionMergedNotification extends Notification {
       oldTitle,
     });
   }
+
+  excerpt() {
+    return null;
+  }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Adds missing `excerpt` method implementation. This breaks the notification dropdown if not implemented.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

![image](https://user-images.githubusercontent.com/7406822/168387851-945b82e5-7b11-44aa-a8da-755b25b994a1.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
