### PR TITLE
feat: dispatch a merging event

### DIFF
--- a/src/Events/MergingDiscussions.php
+++ b/src/Events/MergingDiscussions.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of fof/merge-discussions.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\MergeDiscussions\Events;
+
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
+use Flarum\User\User;
+use Illuminate\Support\Collection;
+
+class MergingDiscussions
+{
+    /**
+     * @var User
+     */
+    public $actor;
+
+    /**
+     * @var Post[]|Collection
+     */
+    public $posts;
+
+    /**
+     * @var Discussion
+     */
+    public $discussion;
+
+    /**
+     * @var Discussion[]|Collection Discussion
+     */
+    public $mergedDiscussions;
+
+    public function __construct(User $actor, Collection $posts, Discussion $discussion, Collection $mergedDiscussions)
+    {
+        $this->actor = $actor;
+        $this->posts = $posts;
+        $this->discussion = $discussion;
+        $this->mergedDiscussions = $mergedDiscussions;
+    }
+}


### PR DESCRIPTION
**Supersedes #50**

**Changes proposed in this pull request:**
Dispatches an event before the discussion is saved and other discussions are deleted. Allows other extensions to introduce custom behavior. I think this is cleaner and keeps the current logic simple and straightforward.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
