### PR TITLE
wip: new merging logic, updated tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,10 @@
                 "name": "fas fa-code-branch fa-flip-vertical",
                 "backgroundColor": "#e74c3c",
                 "color": "#fff"
-            }
+            },
+            "optional-dependencies": [
+                "flarum/lock"
+            ]
         },
         "flagrow": {
             "discuss": "https://discuss.flarum.org/d/19460"
@@ -60,7 +63,8 @@
     },
     "require-dev": {
         "flarum/phpstan": "*",
-        "flarum/testing": "^1.0.0"
+        "flarum/testing": "^1.0.0",
+        "flarum/lock": "*"
     },
     "scripts": {
         "analyse:phpstan": "phpstan analyse",

--- a/src/Api/Controllers/MergeController.php
+++ b/src/Api/Controllers/MergeController.php
@@ -13,10 +13,12 @@ namespace FoF\MergeDiscussions\Api\Controllers;
 
 use Flarum\Api\Controller\AbstractShowController;
 use Flarum\Api\Serializer\DiscussionSerializer;
+use Flarum\Discussion\Discussion;
 use Flarum\Http\RequestUtil;
-use FoF\MergeDiscussions\Commands\MergeDiscussions;
+use FoF\MergeDiscussions\Jobs\MergeDiscussionsJob;
 use FoF\MergeDiscussions\Validators\MergeDiscussionValidator;
 use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
@@ -40,10 +42,16 @@ class MergeController extends AbstractShowController
      */
     protected $validator;
 
-    public function __construct(Dispatcher $bus, MergeDiscussionValidator $validator)
+    /**
+     * @var Queue
+     */
+    protected $queue;
+
+    public function __construct(Dispatcher $bus, MergeDiscussionValidator $validator, Queue $queue)
     {
         $this->bus = $bus;
         $this->validator = $validator;
+        $this->queue = $queue;
     }
 
     /**
@@ -57,17 +65,20 @@ class MergeController extends AbstractShowController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         $actor = RequestUtil::getActor($request);
-        $discussion = Arr::get($request->getQueryParams(), 'id');
+        $discussion = Discussion::findOrFail(Arr::get($request->getQueryParams(), 'id'));
+
+        $actor->assertCan('merge', $discussion);
+
         $ids = Arr::get($request->getParsedBody(), 'ids');
         $ordering = Arr::get($request->getParsedBody(), 'ordering');
 
         $this->validator->assertValid([
-            'discussion_id'       => $discussion,
+            'discussion_id'       => $discussion->id,
             'merging_discussions' => $ids,
         ]);
 
-        return $this->bus->dispatch(
-            new MergeDiscussions($actor, $discussion, $ids, $ordering)
-        );
+        $this->queue->push(new MergeDiscussionsJob($actor, $discussion->id, $ids, $ordering));
+
+        return $discussion;
     }
 }

--- a/src/Api/Controllers/MergeController.php
+++ b/src/Api/Controllers/MergeController.php
@@ -14,7 +14,6 @@ namespace FoF\MergeDiscussions\Api\Controllers;
 use Flarum\Api\Controller\AbstractShowController;
 use Flarum\Api\Serializer\DiscussionSerializer;
 use Flarum\Http\RequestUtil;
-use FoF\MergeDiscussions\Commands\MergeDiscussion;
 use FoF\MergeDiscussions\Commands\MergeDiscussions;
 use FoF\MergeDiscussions\Validators\MergeDiscussionValidator;
 use Illuminate\Contracts\Bus\Dispatcher;

--- a/src/Api/Controllers/MergeController.php
+++ b/src/Api/Controllers/MergeController.php
@@ -15,6 +15,7 @@ use Flarum\Api\Controller\AbstractShowController;
 use Flarum\Api\Serializer\DiscussionSerializer;
 use Flarum\Http\RequestUtil;
 use FoF\MergeDiscussions\Commands\MergeDiscussion;
+use FoF\MergeDiscussions\Commands\MergeDiscussions;
 use FoF\MergeDiscussions\Validators\MergeDiscussionValidator;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
@@ -67,7 +68,7 @@ class MergeController extends AbstractShowController
         ]);
 
         return $this->bus->dispatch(
-            new MergeDiscussion($actor, $discussion, $ids, $ordering)
+            new MergeDiscussions($actor, $discussion, $ids, $ordering)
         );
     }
 }

--- a/src/Api/Controllers/MergePreviewController.php
+++ b/src/Api/Controllers/MergePreviewController.php
@@ -16,6 +16,7 @@ use Flarum\Api\Serializer\DiscussionSerializer;
 use Flarum\Discussion\Discussion;
 use Flarum\Http\RequestUtil;
 use FoF\MergeDiscussions\Commands\MergeDiscussion;
+use FoF\MergeDiscussions\Commands\MergeDiscussions;
 use FoF\MergeDiscussions\Validators\MergeDiscussionValidator;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
@@ -84,7 +85,7 @@ class MergePreviewController extends AbstractShowController
          * @var Discussion
          */
         $discussion = $this->bus->dispatch(
-            new MergeDiscussion($actor, $discussion, $ids, $ordering, false)
+            new MergeDiscussions($actor, $discussion, $ids, $ordering, false)
         );
 
         $discussion->setRelation('posts', $discussion->posts);

--- a/src/Api/Controllers/MergePreviewController.php
+++ b/src/Api/Controllers/MergePreviewController.php
@@ -15,7 +15,6 @@ use Flarum\Api\Controller\AbstractShowController;
 use Flarum\Api\Serializer\DiscussionSerializer;
 use Flarum\Discussion\Discussion;
 use Flarum\Http\RequestUtil;
-use FoF\MergeDiscussions\Commands\MergeDiscussion;
 use FoF\MergeDiscussions\Commands\MergeDiscussions;
 use FoF\MergeDiscussions\Validators\MergeDiscussionValidator;
 use Illuminate\Contracts\Bus\Dispatcher;

--- a/src/Commands/MergeDiscussion.php
+++ b/src/Commands/MergeDiscussion.php
@@ -15,7 +15,8 @@ use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 /**
- * Old code.
+ * Use the `MergeDiscussions` command instead. This class is kept for backwards compatibility.
+ * TODO: Remove in 2.0
  *
  * @deprecated
  */

--- a/src/Commands/MergeDiscussion.php
+++ b/src/Commands/MergeDiscussion.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Arr;
 
 /**
  * Use the `MergeDiscussions` command instead. This class is kept for backwards compatibility.
- * TODO: Remove in 2.0
+ * TODO: Remove in 2.0.
  *
  * @deprecated
  */

--- a/src/Commands/MergeDiscussion.php
+++ b/src/Commands/MergeDiscussion.php
@@ -15,9 +15,9 @@ use Flarum\User\User;
 use Illuminate\Support\Arr;
 
 /**
- * Old code
+ * Old code.
+ *
  * @deprecated
-
  */
 class MergeDiscussion
 {

--- a/src/Commands/MergeDiscussionHandler.php
+++ b/src/Commands/MergeDiscussionHandler.php
@@ -27,7 +27,7 @@ use Throwable;
 
 /**
  * Use the `MergeDiscussions` command instead. This class is kept for backwards compatibility.
- * TODO: Remove in 2.0
+ * TODO: Remove in 2.0.
  *
  * @deprecated
  */

--- a/src/Commands/MergeDiscussionHandler.php
+++ b/src/Commands/MergeDiscussionHandler.php
@@ -25,6 +25,10 @@ use Illuminate\Events\Dispatcher;
 use Illuminate\Support\Collection as SupportCollection;
 use Throwable;
 
+/**
+ * Old code
+ * @deprecated
+ */
 class MergeDiscussionHandler
 {
     /**
@@ -69,12 +73,12 @@ class MergeDiscussionHandler
             $this->fixPostsNumber($discussion);
         }
 
-        /** @var Collection $discussions */
+        /** @var Collection<Discussion> $discussions */
         $discussions = Discussion::query()
             ->with('posts')
             ->findMany($command->ids);
 
-        /** @var Collection $posts */
+        /** @var Collection<Post> $posts */
         $posts = $discussions->pluck('posts')->flatten(1)
             ->reject(function (Post $post) {
                 return $post->type === 'discussionTagged';

--- a/src/Commands/MergeDiscussionHandler.php
+++ b/src/Commands/MergeDiscussionHandler.php
@@ -26,7 +26,8 @@ use Illuminate\Support\Collection as SupportCollection;
 use Throwable;
 
 /**
- * Old code.
+ * Use the `MergeDiscussions` command instead. This class is kept for backwards compatibility.
+ * TODO: Remove in 2.0
  *
  * @deprecated
  */

--- a/src/Commands/MergeDiscussionHandler.php
+++ b/src/Commands/MergeDiscussionHandler.php
@@ -26,7 +26,8 @@ use Illuminate\Support\Collection as SupportCollection;
 use Throwable;
 
 /**
- * Old code
+ * Old code.
+ *
  * @deprecated
  */
 class MergeDiscussionHandler

--- a/src/Commands/MergeDiscussions.php
+++ b/src/Commands/MergeDiscussions.php
@@ -14,12 +14,7 @@ namespace FoF\MergeDiscussions\Commands;
 use Flarum\User\User;
 use Illuminate\Support\Arr;
 
-/**
- * Old code
- * @deprecated
-
- */
-class MergeDiscussion
+class MergeDiscussions
 {
     /**
      * The user performing the action.
@@ -63,7 +58,7 @@ class MergeDiscussion
      * @param       $ordering
      * @param bool  $merge
      */
-    public function __construct(User $actor, $discussionId, $ids, $ordering = 'date', $merge = true)
+    public function __construct(User $actor, $discussionId, $ids, $ordering, $merge = true)
     {
         $this->actor = $actor;
         $this->discussionId = (int) $discussionId;

--- a/src/Commands/MergeDiscussionsHandler.php
+++ b/src/Commands/MergeDiscussionsHandler.php
@@ -163,14 +163,14 @@ class MergeDiscussionsHandler
      */
     protected function lockInvoledDiscussions(User $actor, Discussion $discussion, EloquentCollection $discussions): void
     {
-        if ($this->extensions->isEnabled('flarum-lock') && ! $discussion->is_locked) {
+        if ($this->extensions->isEnabled('flarum-lock') && !$discussion->is_locked) {
             /** @phpstan-ignore-next-line */
             $discussion->is_locked = true;
             $discussion->save();
 
             //$this->events->dispatch(new DiscussionWasLocked($discussion, $actor));
 
-            $discussions->each(function (Discussion $discussion) use ($actor) {
+            $discussions->each(function (Discussion $discussion) {
                 /** @phpstan-ignore-next-line */
                 $discussion->is_locked = true;
                 $discussion->save();

--- a/src/Commands/MergeDiscussionsHandler.php
+++ b/src/Commands/MergeDiscussionsHandler.php
@@ -17,7 +17,6 @@ use Flarum\Discussion\DiscussionRepository;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Lock\Event\DiscussionWasLocked;
 use Flarum\Lock\Event\DiscussionWasUnlocked;
-use Flarum\Post\CommentPost;
 use Flarum\Post\Post;
 use Flarum\User\User;
 use Flarum\User\UserRepository;

--- a/src/Commands/MergeDiscussionsHandler.php
+++ b/src/Commands/MergeDiscussionsHandler.php
@@ -163,19 +163,19 @@ class MergeDiscussionsHandler
      */
     protected function lockInvoledDiscussions(User $actor, Discussion $discussion, EloquentCollection $discussions): void
     {
-        if ($this->extensions->isEnabled('flarum-lock')) {
+        if ($this->extensions->isEnabled('flarum-lock') && ! $discussion->is_locked) {
             /** @phpstan-ignore-next-line */
             $discussion->is_locked = true;
             $discussion->save();
 
-            $this->events->dispatch(new DiscussionWasLocked($discussion, $actor));
+            //$this->events->dispatch(new DiscussionWasLocked($discussion, $actor));
 
             $discussions->each(function (Discussion $discussion) use ($actor) {
                 /** @phpstan-ignore-next-line */
                 $discussion->is_locked = true;
                 $discussion->save();
 
-                $this->events->dispatch(new DiscussionWasLocked($discussion, $actor));
+                //$this->events->dispatch(new DiscussionWasLocked($discussion, $actor));
             });
         }
     }
@@ -195,7 +195,7 @@ class MergeDiscussionsHandler
             $discussion->is_locked = false;
             $discussion->save();
 
-            $this->events->dispatch(new DiscussionWasUnlocked($discussion, $actor));
+            //$this->events->dispatch(new DiscussionWasUnlocked($discussion, $actor));
         }
     }
 

--- a/src/Commands/MergeDiscussionsHandler.php
+++ b/src/Commands/MergeDiscussionsHandler.php
@@ -163,8 +163,8 @@ class MergeDiscussionsHandler
      */
     protected function lockInvoledDiscussions(User $actor, Discussion $discussion, EloquentCollection $discussions): void
     {
+        /** @phpstan-ignore-next-line */
         if ($this->extensions->isEnabled('flarum-lock') && !$discussion->is_locked) {
-            /** @phpstan-ignore-next-line */
             $discussion->is_locked = true;
             $discussion->save();
 

--- a/src/Commands/MergeDiscussionsHandler.php
+++ b/src/Commands/MergeDiscussionsHandler.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace FoF\MergeDiscussions\Commands;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Discussion\DiscussionRepository;
+use Flarum\Extension\ExtensionManager;
+use Flarum\Lock\Event\DiscussionWasLocked;
+use Flarum\Lock\Event\DiscussionWasUnlocked;
+use Flarum\Post\Post;
+use Flarum\User\User;
+use Flarum\User\UserRepository;
+use FoF\MergeDiscussions\Events\DiscussionWasMerged;
+use FoF\MergeDiscussions\Events\MergingDiscussions;
+use FoF\MergeDiscussions\Models\Redirection;
+use FoF\MergeDiscussions\Validators\MergeDiscussionValidator;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection;
+
+class MergeDiscussionsHandler
+{
+    /**
+     * @var ConnectionResolverInterface
+     */
+    protected $db;
+
+    /**
+     * @var UserRepository
+     */
+    protected $users;
+
+    /**
+     * @var DiscussionRepository
+     */
+    protected $discussions;
+
+    /**
+     * @var Dispatcher
+     */
+    protected $events;
+
+    /**
+     * @var MergeDiscussionValidator
+     */
+    protected $validator;
+
+    /**
+     * @var ExtensionManager
+     */
+    protected $extensions;
+    
+    public function __construct(
+        ConnectionResolverInterface $db,
+        UserRepository $users,
+        DiscussionRepository $discussions,
+        Dispatcher $events,
+        MergeDiscussionValidator $validator,
+        ExtensionManager $extensions
+        )
+    {
+        $this->db = $db;
+        $this->users = $users;
+        $this->discussions = $discussions;
+        $this->events = $events;
+        $this->validator = $validator;
+        $this->extensions = $extensions;
+    }
+    
+    /**
+     * Runs the process in a transaction.
+     * Exceptions will always result in no changes.
+     *
+     * @throws \Flarum\User\Exception\PermissionDeniedException
+     * @throws \Illuminate\Validation\ValidationException
+     * @return Discussion
+     */
+    public function handle(MergeDiscussions $command): Discussion
+    {
+        try {
+            $this->db->connection()->beginTransaction();
+            $discussion = $this->process($command);
+            if ($command->merge) {
+                $this->db->connection()->commit();
+            }
+        } catch (\Exception $e) {
+            $this->db->connection()->rollBack();
+            throw $e;
+        }
+
+        return $discussion;
+    }
+
+    public function process(MergeDiscussions $command)
+    {
+        $discussion = $this->discussions->findOrFail($command->discussionId);
+
+        $actor = $command->actor;
+
+        $actor->assertCan('merge', $discussion);
+
+        $postIds = $command->ids;
+        $method = $command->ordering; // can be either 'date' or 'suffix'; default is 'date'
+
+        $this->validator->assertValid([
+            'discussion_id' => $discussion->id,
+            'posts' => $postIds,
+        ]);
+
+        /** @var EloquentCollection $discussions */
+        $discussions = Discussion::query()
+            ->findMany($command->ids);
+
+        /** @var EloquentCollection $posts */
+        $posts = Post::query()
+            ->whereIn('discussion_id', $command->ids)
+            ->orderBy('created_at')
+            ->get();
+
+        $this->validator->assertValid([
+            'posts' => $posts->toArray(),
+        ]);
+
+        $this->events->dispatch(new MergingDiscussions($actor, $posts, $discussion, $discussions, $method));
+
+        $this->lockInvoledDiscussions($actor, $discussion, $discussions);
+
+        $result = $this->useMethod($method, $discussion, $posts);
+
+        $this->createRedirectsFromMergedDiscussions($discussion, $discussions);
+
+        $this->unlockTargetDiscussion($actor, $discussion);
+
+        $this->events->dispatch(new DiscussionWasMerged($actor, $posts, $discussion, $discussions));
+
+        return $result;
+    }
+
+    protected function useMethod(string $method, Discussion $discussion, EloquentCollection $posts): Discussion
+    {
+        return $this->$method($discussion, $posts);
+    }
+
+    /**
+     * If `flarum/lock` is enabled, lock all involved discussions before merging.
+     *
+     * @param User $actor
+     * @param Discussion $discussion
+     * @param EloquentCollection $discussions
+     * @return void
+     */
+    protected function lockInvoledDiscussions(User $actor, Discussion $discussion, EloquentCollection $discussions): void
+    {
+        if ($this->extensions->isEnabled('flarum-lock')) {
+            /** @phpstan-ignore-next-line */
+            $discussion->is_locked = true;
+            $discussion->save();
+
+            $this->events->dispatch(new DiscussionWasLocked($discussion, $actor));
+
+            $discussions->each(function (Discussion $discussion) use ($actor) {
+                /** @phpstan-ignore-next-line */
+                $discussion->is_locked = true;
+                $discussion->save();
+
+                $this->events->dispatch(new DiscussionWasLocked($discussion, $actor));
+            });
+        }
+    }
+
+    /**
+     * If `flarum/lock` is enabled, unlock the target discussion after merging.
+     *
+     * @param User $actor
+     * @param Discussion $discussion
+     * @return void
+     */
+    protected function unlockTargetDiscussion(User $actor, Discussion $discussion): void
+    {
+        if ($this->extensions->isEnabled('flarum-lock')) {
+            /** @phpstan-ignore-next-line */
+            $discussion->is_locked = false;
+            $discussion->save();
+
+            $this->events->dispatch(new DiscussionWasUnlocked($discussion, $actor));
+        }
+    }
+
+    /**
+     * Creates redirects from merged discussions, and deletes the old Discussion entities.
+     *
+     * @param Discussion $targetDiscussion
+     * @param EloquentCollection $discussions
+     * @return void
+     */
+    protected function createRedirectsFromMergedDiscussions(Discussion $targetDiscussion, EloquentCollection $discussions): void
+    {
+        $discussions->each(function (Discussion $discussion) use ($targetDiscussion) {
+            Redirection::build($discussion, $targetDiscussion);
+
+            $discussion->delete();
+        });
+    }
+
+    protected function date(Discussion $discussion, EloquentCollection $posts): Discussion
+    {
+        $db = $this->db->connection();
+
+        // Create number gaps in discussion
+        $selectCreatedAt = $db->query()
+            ->select('created_at')
+            ->from('posts')
+            ->whereIn('id', $posts->pluck('id'));
+
+        $selectCount = $db->query()
+            ->mergeBindings($selectCreatedAt)
+            ->selectRaw('COUNT(created_at) as count')
+            ->from($db->raw("({$selectCreatedAt->toSql()}) as sp"))
+            ->whereColumn('posts.created_at', '>=', $db->raw('sp.created_at'));
+
+        $db->table('posts')
+            ->mergeBindings($selectCount)
+            ->where('discussion_id', $discussion->id)
+            ->orderBy('number', 'desc')
+            ->update(['number' => $db->raw("number + ({$selectCount->toSql()})")]);
+
+        // To fill the gaps with the new posts,
+        // we query the posts that will be ordered right before the new ones,
+        // so that we can calculate the numbers of the new posts.
+        $max = $db->query()
+            ->select('number')
+            ->from('posts')
+            ->where('discussion_id', $discussion->id)
+            ->whereColumn($db->raw('r.created_at'), '>', 'posts.created_at')
+            ->orderBy('number', 'desc')
+            ->limit(1);
+
+        $numbers = $db->query()
+            ->mergeBindings($max)
+            ->mergeBindings($selectCreatedAt)
+            ->selectRaw("DISTINCT ({$max->toSql()}) as number")
+            ->from($db->raw("({$selectCreatedAt->toSql()}) as r"))
+            ->get();
+
+        // Now we get the checkpoints and use them to calculate new post numbers
+        $checkpointPosts = Post::query()
+            ->where('discussion_id', $discussion->id)
+            ->whereIn('number', $numbers->pluck('number')->toArray())
+            ->get();
+
+        $merged = $checkpointPosts->merge($posts)->sortBy('created_at')->values();
+
+        $merged->map(function (Post $post, int $key) use ($merged, $checkpointPosts, $discussion) {
+            $prev = $merged[$key-1] ?? null;
+
+            if ($prev && ! $checkpointPosts->firstWhere('id', $post->id)) {
+                $post->number = $prev->number + 1;
+                $post->discussion_id = $discussion->id;
+
+                $post->save();
+            }
+
+            return $post;
+        });
+
+        if (Carbon::parse($discussion->firstPost->created_at) > Carbon::parse($posts->first()->created_at)) {
+            $discussion->setFirstPost($posts->first());
+        }
+
+        $discussion->refreshCommentCount();
+        $discussion->refreshParticipantCount();
+        $discussion->refreshLastPost();
+
+        $discussion->save();
+
+        return $discussion;
+    }
+
+    /**
+     * Pushes the merged posts to the end of the discussion.
+     *
+     * @param Discussion $discussion
+     * @param EloquentCollection<Post> $posts
+     * @return Discussion
+     */
+    protected function suffix(Discussion $discussion, EloquentCollection $posts): Discussion
+    {
+        $numberDifference = $discussion->posts()->max('number') - $posts->first()->number + 1;
+        $posts->toQuery()->update([
+            'discussion_id' => $discussion->id,
+            /** @phpstan-ignore-next-line */
+            'number' => $this->db->raw("number + $numberDifference"),
+        ]);
+
+        $discussion->refreshCommentCount();
+        $discussion->refreshParticipantCount();
+        $discussion->refreshLastPost();
+
+        $discussion->save();
+
+        return $discussion;
+    }
+}

--- a/src/Events/MergingDiscussions.php
+++ b/src/Events/MergingDiscussions.php
@@ -38,11 +38,17 @@ class MergingDiscussions
      */
     public $mergedDiscussions;
 
-    public function __construct(User $actor, Collection $posts, Discussion $discussion, Collection $mergedDiscussions)
+    /**
+     * @var string
+     */
+    public $ordering;
+
+    public function __construct(User $actor, Collection $posts, Discussion $discussion, Collection $mergedDiscussions, string $ordering = 'date')
     {
         $this->actor = $actor;
         $this->posts = $posts;
         $this->discussion = $discussion;
         $this->mergedDiscussions = $mergedDiscussions;
+        $this->ordering = $ordering;
     }
 }

--- a/src/Jobs/MergeDiscussionsJob.php
+++ b/src/Jobs/MergeDiscussionsJob.php
@@ -47,6 +47,7 @@ class MergeDiscussionsJob extends AbstractJob
         /** @var Discussion $discussion */
         $discussion = $bus->dispatch(new MergeDiscussions($this->actor, $this->discussionId, $this->ids, $this->ordering, $this->merge));
 
+        /** @phpstan-ignore-next-line */
         if ($extensions->isEnabled('flarum-lock') && $discussion->is_locked) {
             $discussion->is_locked = false;
             $discussion->save();

--- a/src/Jobs/MergeDiscussionsJob.php
+++ b/src/Jobs/MergeDiscussionsJob.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace FoF\MergeDiscussions\Jobs;
+
+use Flarum\Queue\AbstractJob;
+use Flarum\User\User;
+use FoF\MergeDiscussions\Commands\MergeDiscussions;
+use Illuminate\Bus\Dispatcher;
+
+class MergeDiscussionsJob extends AbstractJob
+{
+    protected $actor;
+
+    protected $discussionId;
+
+    protected $ids;
+
+    protected $ordering;
+
+    protected $merge;
+    
+    public function __construct(User $actor, int $discussionId, array $ids, string $ordering = 'date', bool $merge = true)
+    {
+        $this->actor = $actor;
+        $this->discussionId = (int) $discussionId;
+        $this->ids = $ids;
+        $this->ordering = $ordering;
+        $this->merge = $merge;
+    }
+    
+    public function handle(Dispatcher $bus)
+    {
+        $bus->dispatch(new MergeDiscussions($this->actor, $this->discussionId, $this->ids, $this->ordering, $this->merge));
+    }
+}

--- a/src/Jobs/MergeDiscussionsJob.php
+++ b/src/Jobs/MergeDiscussionsJob.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/merge-discussions.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\MergeDiscussions\Jobs;
 
 use Flarum\Queue\AbstractJob;
@@ -18,7 +27,7 @@ class MergeDiscussionsJob extends AbstractJob
     protected $ordering;
 
     protected $merge;
-    
+
     public function __construct(User $actor, int $discussionId, array $ids, string $ordering = 'date', bool $merge = true)
     {
         $this->actor = $actor;
@@ -27,7 +36,7 @@ class MergeDiscussionsJob extends AbstractJob
         $this->ordering = $ordering;
         $this->merge = $merge;
     }
-    
+
     public function handle(Dispatcher $bus)
     {
         $bus->dispatch(new MergeDiscussions($this->actor, $this->discussionId, $this->ids, $this->ordering, $this->merge));

--- a/src/Jobs/MergeDiscussionsJob.php
+++ b/src/Jobs/MergeDiscussionsJob.php
@@ -13,7 +13,6 @@ namespace FoF\MergeDiscussions\Jobs;
 
 use Flarum\Discussion\Discussion;
 use Flarum\Extension\ExtensionManager;
-use Flarum\Lock\Event\DiscussionWasUnlocked;
 use Flarum\Notification\NotificationSyncer;
 use Flarum\Queue\AbstractJob;
 use Flarum\User\User;

--- a/src/Jobs/MergeDiscussionsJob.php
+++ b/src/Jobs/MergeDiscussionsJob.php
@@ -47,13 +47,6 @@ class MergeDiscussionsJob extends AbstractJob
         /** @var Discussion $discussion */
         $discussion = $bus->dispatch(new MergeDiscussions($this->actor, $this->discussionId, $this->ids, $this->ordering, $this->merge));
 
-        /** @phpstan-ignore-next-line */
-        if ($extensions->isEnabled('flarum-lock') && $discussion->is_locked) {
-            $discussion->is_locked = false;
-            $discussion->save();
-
-            //$events->dispatch(new DiscussionWasUnlocked($discussion, $this->actor));
-        }
         // TODO: send notification on merge completion
     }
 }

--- a/tests/integration/api/MergeTest.php
+++ b/tests/integration/api/MergeTest.php
@@ -232,6 +232,12 @@ class MergeTest extends TestCase
 
         $posts = $discussion->posts;
 
+        foreach ($posts as $post) {
+            if ($post !== $posts->last()) {
+                $this->assertEquals('comment', $post->type);
+            }
+        }
+
         $this->assertEquals(11, $posts->count());
 
         // Check the posts were ordered as expected by date/time
@@ -283,6 +289,12 @@ class MergeTest extends TestCase
 
         $posts = $discussion->posts()->get();
 
+        foreach ($posts as $post) {
+            if ($post !== $posts->last()) {
+                $this->assertEquals('comment', $post->type);
+            }
+        }
+
         $this->assertEquals(11, $posts->count());
 
         // check the posts were ordered as expected
@@ -292,6 +304,10 @@ class MergeTest extends TestCase
         $this->assertPostAttrs($posts[2], $to, 3, 3);
         $this->assertPostAttrs($posts[3], $to, 4, 4);
         $this->assertPostAttrs($posts[4], $to, 5, 5);
+
+        // $this->assertEquals('discussionLocked', $posts[5]->type);
+        // $this->assertEquals(6, $posts[5]->number);
+
         $this->assertPostAttrs($posts[5], $from, 1, 6);
         $this->assertPostAttrs($posts[6], $from, 2, 7);
         $this->assertPostAttrs($posts[7], $from, 3, 8);
@@ -355,6 +371,12 @@ class MergeTest extends TestCase
         $posts = $discussion->posts()->orderBy('created_at', 'asc')->get();
 
         $this->assertEquals(16, $posts->count());
+
+        foreach ($posts as $post) {
+            if ($post !== $posts->last()) {
+                $this->assertEquals('comment', $post->type);
+            }
+        }
 
         // Check the posts were ordered as expected by date/time
 

--- a/tests/integration/api/MergeTest.php
+++ b/tests/integration/api/MergeTest.php
@@ -186,8 +186,8 @@ class MergeTest extends TestCase
     public function discussionMergeData(): array
     {
         return [
-            [1, 2],
-            [2, 1],
+            [1, 2], // Merging newer discussion into older
+            [2, 1], // Merging older discussion into newer
         ];
     }
 

--- a/tests/integration/api/MergeTest.php
+++ b/tests/integration/api/MergeTest.php
@@ -157,6 +157,7 @@ class MergeTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider invalidDiscussionData
      */
     public function cannot_merge_discussion_with_invalid_data(int $to, int $from, string $pointer)
@@ -176,7 +177,7 @@ class MergeTest extends TestCase
 
         $this->assertArrayHasKey('errors', $data);
         $this->assertCount(1, $data['errors']);
-        $this->assertEquals('/data/attributes/' . $pointer, $data['errors'][0]['source']['pointer']);
+        $this->assertEquals('/data/attributes/'.$pointer, $data['errors'][0]['source']['pointer']);
     }
 
     public function discussionMergeData(): array
@@ -191,7 +192,7 @@ class MergeTest extends TestCase
     {
         return [
             [1, 100, 'merging_discussions'],
-            [100, 1, 'discussion_id']
+            [100, 1, 'discussion_id'],
         ];
     }
 

--- a/tests/integration/api/MergeTest.php
+++ b/tests/integration/api/MergeTest.php
@@ -13,6 +13,7 @@ namespace FoF\MergeDiscussions\Tests\integration\api;
 
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 
@@ -24,6 +25,7 @@ class MergeTest extends TestCase
     {
         parent::setUp();
 
+        $this->extension('flarum-lock');
         $this->extension('fof-merge-discussions');
 
         $this->prepareDatabase([
@@ -153,11 +155,43 @@ class MergeTest extends TestCase
     //     $this->assertEquals(403, $response->getStatusCode());
     // }
 
+    /**
+     * @test
+     * @dataProvider invalidDiscussionData
+     */
+    public function cannot_merge_discussion_with_invalid_data(int $to, int $from, string $pointer)
+    {
+        $response = $this->send(
+            $this->request('POST', "/api/discussions/$to/merge", [
+                'json' => [
+                    'ids' => [$from],
+                ],
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(422, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayHasKey('errors', $data);
+        $this->assertCount(1, $data['errors']);
+        $this->assertEquals('/data/attributes/' . $pointer, $data['errors'][0]['source']['pointer']);
+    }
+
     public function discussionMergeData(): array
     {
         return [
             [1, 2],
             [2, 1],
+        ];
+    }
+
+    public function invalidDiscussionData(): array
+    {
+        return [
+            [1, 100, 'merging_discussions'],
+            [100, 1, 'discussion_id']
         ];
     }
 
@@ -187,65 +221,31 @@ class MergeTest extends TestCase
 
         $discussion = Discussion::find($to);
 
-        $this->assertEquals(10, $discussion->comment_count);
+        $this->assertEquals(10, $discussion->comment_count, 'Unexpected comment count');
+        $this->assertEquals(11, $discussion->posts->count(), 'Unexpected post count');
         $this->assertEquals(2, $discussion->participant_count);
+        $this->assertFalse($discussion->is_locked, 'Discussion was not unlocked after merge');
 
-        $posts = $discussion->posts()->orderBy('created_at', 'asc')->get();
+        $posts = $discussion->posts;
 
         $this->assertEquals(11, $posts->count());
 
         // Check the posts were ordered as expected by date/time
-        $this->assertEquals('Post 1 in Discussion 1', $posts[0]->content);
-        $this->assertEquals('comment', $posts[0]->type);
-        $this->assertEquals(1, $posts[0]->number);
-
-        $this->assertEquals('Post 1 in Discussion 2', $posts[1]->content);
-        $this->assertEquals('comment', $posts[1]->type);
-        $this->assertEquals(2, $posts[1]->number);
-
-        $this->assertEquals('Post 2 in Discussion 1', $posts[2]->content);
-        $this->assertEquals('comment', $posts[2]->type);
-        $this->assertEquals(3, $posts[2]->number);
-
-        $this->assertEquals('Post 2 in Discussion 2', $posts[3]->content);
-        $this->assertEquals('comment', $posts[3]->type);
-        $this->assertEquals(4, $posts[3]->number);
-
-        $this->assertEquals('Post 3 in Discussion 1', $posts[4]->content);
-        $this->assertEquals('comment', $posts[4]->type);
-        $this->assertEquals(5, $posts[4]->number);
-
-        $this->assertEquals('Post 3 in Discussion 2', $posts[5]->content);
-        $this->assertEquals('comment', $posts[5]->type);
-        $this->assertEquals(6, $posts[5]->number);
-
-        $this->assertEquals('Post 4 in Discussion 1', $posts[6]->content);
-        $this->assertEquals('comment', $posts[6]->type);
-        $this->assertEquals(7, $posts[6]->number);
-
-        $this->assertEquals('Post 4 in Discussion 2', $posts[7]->content);
-        $this->assertEquals('comment', $posts[7]->type);
-        $this->assertEquals(8, $posts[7]->number);
-
-        $this->assertEquals('Post 5 in Discussion 2', $posts[8]->content);
-        $this->assertEquals('comment', $posts[8]->type);
-        $this->assertEquals(9, $posts[8]->number);
-
-        $this->assertEquals('Post 5 in Discussion 1', $posts[9]->content);
-        $this->assertEquals('comment', $posts[9]->type);
-        $this->assertEquals(10, $posts[9]->number);
+        $this->assertPostAttrs($posts[0], 1, 1, 1);
+        $this->assertPostAttrs($posts[1], 2, 1, 2, $posts[0]);
+        $this->assertPostAttrs($posts[2], 1, 2, 3, $posts[1]);
+        $this->assertPostAttrs($posts[3], 2, 2, 4, $posts[2]);
+        $this->assertPostAttrs($posts[4], 1, 3, 5, $posts[3]);
+        $this->assertPostAttrs($posts[5], 2, 3, 6, $posts[4]);
+        $this->assertPostAttrs($posts[6], 1, 4, 7, $posts[5]);
+        $this->assertPostAttrs($posts[7], 2, 4, 8, $posts[6]);
+        $this->assertPostAttrs($posts[8], 2, 5, 9, $posts[7]);
+        $this->assertPostAttrs($posts[9], 1, 5, 10, $posts[8]);
 
         $this->assertEquals('discussionMerged', $posts[10]->type);
         $this->assertEquals(11, $posts[10]->number);
 
-        // Test the merged discussion has a 301 redirect to the target discussion
-
-        $response = $this->send(
-            $this->request('GET', "/d/$from", [])
-        );
-
-        $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals("/d/$to", $response->getHeader('Location')[0]);
+        $this->assertRedirection($from, $to);
     }
 
     /**
@@ -283,56 +283,41 @@ class MergeTest extends TestCase
 
         // check the posts were ordered as expected
 
-        $this->assertEquals("Post 1 in Discussion $to", $posts[0]->content);
-        $this->assertEquals('comment', $posts[0]->type);
-        $this->assertEquals(1, $posts[0]->number);
-
-        $this->assertEquals("Post 2 in Discussion $to", $posts[1]->content);
-        $this->assertEquals('comment', $posts[1]->type);
-        $this->assertEquals(2, $posts[1]->number);
-
-        $this->assertEquals("Post 3 in Discussion $to", $posts[2]->content);
-        $this->assertEquals('comment', $posts[2]->type);
-        $this->assertEquals(3, $posts[2]->number);
-
-        $this->assertEquals("Post 4 in Discussion $to", $posts[3]->content);
-        $this->assertEquals('comment', $posts[3]->type);
-        $this->assertEquals(4, $posts[3]->number);
-
-        $this->assertEquals("Post 5 in Discussion $to", $posts[4]->content);
-        $this->assertEquals('comment', $posts[4]->type);
-        $this->assertEquals(5, $posts[4]->number);
-
-        $this->assertEquals("Post 1 in Discussion $from", $posts[5]->content);
-        $this->assertEquals('comment', $posts[5]->type);
-        $this->assertEquals(6, $posts[5]->number);
-
-        $this->assertEquals("Post 2 in Discussion $from", $posts[6]->content);
-        $this->assertEquals('comment', $posts[6]->type);
-        $this->assertEquals(7, $posts[6]->number);
-
-        $this->assertEquals("Post 3 in Discussion $from", $posts[7]->content);
-        $this->assertEquals('comment', $posts[7]->type);
-        $this->assertEquals(8, $posts[7]->number);
-
-        $this->assertEquals("Post 4 in Discussion $from", $posts[8]->content);
-        $this->assertEquals('comment', $posts[8]->type);
-        $this->assertEquals(9, $posts[8]->number);
-
-        $this->assertEquals("Post 5 in Discussion $from", $posts[9]->content);
-        $this->assertEquals('comment', $posts[9]->type);
-        $this->assertEquals(10, $posts[9]->number);
+        $this->assertPostAttrs($posts[0], $to, 1, 1);
+        $this->assertPostAttrs($posts[1], $to, 2, 2);
+        $this->assertPostAttrs($posts[2], $to, 3, 3);
+        $this->assertPostAttrs($posts[3], $to, 4, 4);
+        $this->assertPostAttrs($posts[4], $to, 5, 5);
+        $this->assertPostAttrs($posts[5], $from, 1, 6);
+        $this->assertPostAttrs($posts[6], $from, 2, 7);
+        $this->assertPostAttrs($posts[7], $from, 3, 8);
+        $this->assertPostAttrs($posts[8], $from, 4, 9);
+        $this->assertPostAttrs($posts[9], $from, 5, 10);
 
         $this->assertEquals('discussionMerged', $posts[10]->type);
         $this->assertEquals(11, $posts[10]->number);
 
-        // Test the merged discussion has a 301 redirect to the target discussion
+        $this->assertRedirection($from, $to);
+    }
 
+    protected function assertPostAttrs(Post $post, int $expectedDiscussion, int $expectedPostContentNumber, int $expectedNumber, Post $previousPost = null): void
+    {
+        $this->assertEquals("Post $expectedPostContentNumber in Discussion $expectedDiscussion", $post->content, "Post content incorrect: $post->content");
+        $this->assertEquals('comment', $post->type, "Post type incorrect: $post->type");
+        $this->assertEquals($expectedNumber, $post->number, "Post number incorrect: $post->number");
+
+        if ($previousPost) {
+            $this->assertTrue(Carbon::parse($post->created_at) > Carbon::parse($previousPost->created_at), "Post $post->id created_at ($post->created_at) is after previous post $previousPost->id created_at ($previousPost->created_at)");
+        }
+    }
+
+    protected function assertRedirection(int $from, int $to, int $statusCode = 301): void
+    {
         $response = $this->send(
             $this->request('GET', "/d/$from", [])
         );
 
-        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals($statusCode, $response->getStatusCode());
         $this->assertEquals("/d/$to", $response->getHeader('Location')[0]);
     }
 
@@ -368,84 +353,28 @@ class MergeTest extends TestCase
         $this->assertEquals(16, $posts->count());
 
         // Check the posts were ordered as expected by date/time
-        $this->assertEquals('Post 1 in Discussion 1', $posts[0]->content);
-        $this->assertEquals('comment', $posts[0]->type);
-        $this->assertEquals(1, $posts[0]->number);
 
-        $this->assertEquals('Post 1 in Discussion 2', $posts[1]->content);
-        $this->assertEquals('comment', $posts[1]->type);
-        $this->assertEquals(2, $posts[1]->number);
-
-        $this->assertEquals('Post 2 in Discussion 1', $posts[2]->content);
-        $this->assertEquals('comment', $posts[2]->type);
-        $this->assertEquals(3, $posts[2]->number);
-
-        $this->assertEquals('Post 2 in Discussion 2', $posts[3]->content);
-        $this->assertEquals('comment', $posts[3]->type);
-        $this->assertEquals(4, $posts[3]->number);
-
-        $this->assertEquals('Post 1 in Discussion 3', $posts[4]->content);
-        $this->assertEquals('comment', $posts[4]->type);
-        $this->assertEquals(5, $posts[4]->number);
-
-        $this->assertEquals('Post 2 in Discussion 3', $posts[5]->content);
-        $this->assertEquals('comment', $posts[5]->type);
-        $this->assertEquals(6, $posts[5]->number);
-
-        $this->assertEquals('Post 3 in Discussion 1', $posts[6]->content);
-        $this->assertEquals('comment', $posts[6]->type);
-        $this->assertEquals(7, $posts[6]->number);
-
-        $this->assertEquals('Post 3 in Discussion 2', $posts[7]->content);
-        $this->assertEquals('comment', $posts[7]->type);
-        $this->assertEquals(8, $posts[7]->number);
-
-        $this->assertEquals('Post 3 in Discussion 3', $posts[8]->content);
-        $this->assertEquals('comment', $posts[8]->type);
-        $this->assertEquals(9, $posts[8]->number);
-
-        $this->assertEquals('Post 4 in Discussion 1', $posts[9]->content);
-        $this->assertEquals('comment', $posts[9]->type);
-        $this->assertEquals(10, $posts[9]->number);
-
-        $this->assertEquals('Post 4 in Discussion 2', $posts[10]->content);
-        $this->assertEquals('comment', $posts[10]->type);
-        $this->assertEquals(11, $posts[10]->number);
-
-        $this->assertEquals('Post 5 in Discussion 2', $posts[11]->content);
-        $this->assertEquals('comment', $posts[11]->type);
-        $this->assertEquals(12, $posts[11]->number);
-
-        $this->assertEquals('Post 4 in Discussion 3', $posts[12]->content);
-        $this->assertEquals('comment', $posts[12]->type);
-        $this->assertEquals(13, $posts[12]->number);
-
-        $this->assertEquals('Post 5 in Discussion 1', $posts[13]->content);
-        $this->assertEquals('comment', $posts[13]->type);
-        $this->assertEquals(14, $posts[13]->number);
-
-        $this->assertEquals('Post 5 in Discussion 3', $posts[14]->content);
-        $this->assertEquals('comment', $posts[14]->type);
-        $this->assertEquals(15, $posts[14]->number);
+        $this->assertPostAttrs($posts[0], 1, 1, 1);
+        $this->assertPostAttrs($posts[1], 2, 1, 2);
+        $this->assertPostAttrs($posts[2], 1, 2, 3);
+        $this->assertPostAttrs($posts[3], 2, 2, 4);
+        $this->assertPostAttrs($posts[4], 3, 1, 5);
+        $this->assertPostAttrs($posts[5], 3, 2, 6);
+        $this->assertPostAttrs($posts[6], 1, 3, 7);
+        $this->assertPostAttrs($posts[7], 2, 3, 8);
+        $this->assertPostAttrs($posts[8], 3, 3, 9);
+        $this->assertPostAttrs($posts[9], 1, 4, 10);
+        $this->assertPostAttrs($posts[10], 2, 4, 11);
+        $this->assertPostAttrs($posts[11], 2, 5, 12);
+        $this->assertPostAttrs($posts[12], 3, 4, 13);
+        $this->assertPostAttrs($posts[13], 1, 5, 14);
+        $this->assertPostAttrs($posts[14], 3, 5, 15);
 
         $this->assertEquals('discussionMerged', $posts[15]->type);
         $this->assertEquals(16, $posts[15]->number);
 
-        // Test the merged discussion has a 301 redirect to the target discussion
-
-        $response = $this->send(
-            $this->request('GET', '/d/2', [])
-        );
-
-        $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('/d/1', $response->getHeader('Location')[0]);
-
-        $response = $this->send(
-            $this->request('GET', '/d/3', [])
-        );
-
-        $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals('/d/1', $response->getHeader('Location')[0]);
+        $this->assertRedirection(2, 1);
+        $this->assertRedirection(3, 1);
     }
 
     // TODO: Fix this test

--- a/tests/integration/api/MergeTest.php
+++ b/tests/integration/api/MergeTest.php
@@ -160,7 +160,7 @@ class MergeTest extends TestCase
      *
      * @dataProvider invalidDiscussionData
      */
-    public function cannot_merge_discussion_with_invalid_data(int $to, int $from, string $pointer)
+    public function cannot_merge_discussion_with_invalid_data(int $to, int $from, int $statusCode, string $pointer = null)
     {
         $response = $this->send(
             $this->request('POST', "/api/discussions/$to/merge", [
@@ -171,13 +171,16 @@ class MergeTest extends TestCase
             ])
         );
 
-        $this->assertEquals(422, $response->getStatusCode());
+        $this->assertEquals($statusCode, $response->getStatusCode());
 
         $data = json_decode($response->getBody()->getContents(), true);
 
         $this->assertArrayHasKey('errors', $data);
         $this->assertCount(1, $data['errors']);
-        $this->assertEquals('/data/attributes/'.$pointer, $data['errors'][0]['source']['pointer']);
+
+        if ($pointer) {
+            $this->assertEquals('/data/attributes/'.$pointer, $data['errors'][0]['source']['pointer']);
+        }
     }
 
     public function discussionMergeData(): array
@@ -191,8 +194,8 @@ class MergeTest extends TestCase
     public function invalidDiscussionData(): array
     {
         return [
-            [1, 100, 'merging_discussions'],
-            [100, 1, 'discussion_id'],
+            [1, 100, 422, 'merging_discussions'],
+            [100, 1, 404],
         ];
     }
 


### PR DESCRIPTION
- [x] Delegate merge operations to the queue, where available
- [x] If `flarum/lock` is available, lock the discussion(s) whilst the merge is pending/in-progress
- [ ] Notify the merge actor when complete
- [x] New merge handler, should overcome previous numbering and constraint related issues
- [x] Tests for most common merge operations

New handler inspired by https://github.com/SychO9/flarum-move-posts