### PR TITLE
fix: merge preview when order is not chronological (merge order: append)

### DIFF
--- a/js/src/forum/components/DiscussionMergeModal.js
+++ b/js/src/forum/components/DiscussionMergeModal.js
@@ -211,17 +211,21 @@ export default class DiscussionMergeModal extends Modal {
 
         if (payload.included) payload.included.map(app.store.pushObject.bind(app.store));
 
-        payload.data.relationships.posts.data
-          .map((record) => app.store.getById('posts', record.id))
-          .sort((a, b) => a.createdAt() - b.createdAt())
-          .forEach((p, i) => {
-            p.number(number++);
+        let posts = payload.data.relationships.posts.data.map((record) => app.store.getById('posts', record.id));
 
-            payload.data.relationships.posts.data[i] = {
-              type: 'posts',
-              id: p.id(),
-            };
-          });
+        // apply date-sort only if ordering === 'date'
+        if (this.order() === 'date') {
+          posts.sort((a, b) => a.createdAt() - b.createdAt());
+        }
+
+        // then renumber & rebuild the relationship array
+        posts.forEach((p, i) => {
+          p.number(i + 1);
+          payload.data.relationships.posts.data[i] = {
+            type: 'posts',
+            id: p.id(),
+          };
+        });
 
         const discussion = app.store.createRecord(payload.data.type, payload.data);
         discussion.payload = payload;


### PR DESCRIPTION
We noticed that the preview of the merged discussion when the **Merge order** option is `Add merged posts at the end of the discussion` is not correct. It always displays the merged discussion as the **Merge option** is `Merge posts after creation date`.
Once merged, though, the post order is correct and matches the selected **Merge option.** So the issue lies only in the preview.

<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Change for component `DiscussionMergeModal`: 
- Move sorting posts by date inside an `if` condition. Post ordering by date in the frontend should be done only when `this.order() === 'date'`

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
