### PR TITLE
fix: reset preview on ordering change to prevent stale preview

### DIFF
--- a/js/src/forum/components/DiscussionMergeModal.js
+++ b/js/src/forum/components/DiscussionMergeModal.js
@@ -199,6 +199,7 @@ export default class DiscussionMergeModal extends Modal {
 
   changeOrdering(key) {
     this.order(key);
+    if (this.preview) delete this.preview;
   }
 
   loadPreview() {


### PR DESCRIPTION
When switching the post ordering in the merge discussions modal, the preview wasn't reset, resulting in an outdated preview being shown.

<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
This commit adds a check to delete `this.preview` when the ordering changes, ensuring the preview is refreshed properly.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
![merge-preview-change-order](https://github.com/user-attachments/assets/66a489ad-8e0c-4074-957a-3bdfdbb8e950)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
