### PR TITLE
[2.x] fix: allow searching for discussions with ids 1-99 (<3 chars)

### DIFF
--- a/js/src/forum/components/DiscussionMergeModal.tsx
+++ b/js/src/forum/components/DiscussionMergeModal.tsx
@@ -26,7 +26,6 @@ export default class DiscussionMergeModal extends FormModal<any> {
   type!: Stream<string>;
   order!: Stream<string>;
   merging!: Discussion[];
-  results!: any[];
   preview!: any;
   loadingPreview!: boolean;
   searchState!: SearchState;
@@ -45,7 +44,6 @@ export default class DiscussionMergeModal extends FormModal<any> {
       this.merging.push(this.attrs.preselect);
     }
 
-    this.results = [];
     this.preview = null;
 
     this.loadingPreview = false;
@@ -138,13 +136,13 @@ export default class DiscussionMergeModal extends FormModal<any> {
         <Form>
           <div className="Forum-group">{this.orderItems().toArray()}</div>
           <div className="Form-group">{this.typeItems().toArray()}</div>
-          <p className="help">
-            {app.translator.trans(`fof-merge-discussions.forum.modal.type_${this.type()}_help_text`, {
-              title: this.discussion.title(),
-            })}
-          </p>
           <div className={classList('FormGroup', this.disabled() && 'hidden')}>
-            <DiscussionSearch state={this.searchState} onSelect={this.select.bind(this)} ignore={this.discussion.id()} />
+            <p className="help">
+              {app.translator.trans(`fof-merge-discussions.forum.modal.type_${this.type()}_help_text`, {
+                title: this.discussion.title(),
+              })}
+            </p>
+            <DiscussionSearch state={this.searchState} onSelect={this.select.bind(this)} ignore={this.shouldIgnoreResult.bind(this)} />
           </div>
           <div className="Form-group MergeDiscussions-Discussions">
             <ul>
@@ -333,5 +331,20 @@ export default class DiscussionMergeModal extends FormModal<any> {
     }
 
     return requestData;
+  }
+
+  /**
+   * Ignores the current discussion we're merging from/to, and any discussions already selected for merging.
+   * We need to maintain the same array reference for the ignore list, as it's passed to a constructor.
+   */
+  shouldIgnoreResult(discussion: Discussion): boolean {
+    const id = discussion.id() || '';
+    console.log(
+      'should ignore',
+      id,
+      this.discussion.id(),
+      this.merging.some((d) => d.id() === id)
+    );
+    return id === this.discussion.id() || this.merging.some((d) => d.id() === id);
   }
 }

--- a/js/src/forum/components/DiscussionSearch.tsx
+++ b/js/src/forum/components/DiscussionSearch.tsx
@@ -10,10 +10,12 @@ import type Mithril from 'mithril';
 export interface DiscussionSearchAttrs extends Mithril.Attributes {
   state: any;
   onSelect: (discussion: Discussion) => void;
-  ignore: string;
+  ignore?: (discussion: Discussion) => boolean;
 }
 
 export default class DiscussionSearch extends Search<DiscussionSearchAttrs> {
+  protected static MIN_SEARCH_LEN = 1;
+
   oncreate(vnode: Mithril.VnodeDOM<DiscussionSearchAttrs, this>): void {
     super.oncreate(vnode);
 

--- a/js/src/forum/components/DiscussionSearchSource.tsx
+++ b/js/src/forum/components/DiscussionSearchSource.tsx
@@ -1,18 +1,21 @@
 import app from 'flarum/forum/app';
+import { SearchSource } from 'flarum/forum/components/Search';
 import highlight from 'flarum/common/helpers/highlight';
 import type Discussion from 'flarum/common/models/Discussion';
 import type Mithril from 'mithril';
 
-export default class DiscussionSearchSource {
+export default class DiscussionSearchSource implements SearchSource {
   protected results: Map<string, Discussion[]> = new Map();
+  protected ignore: (discussion: Discussion) => boolean;
   protected onSelect: (discussion: Discussion) => void;
-  protected ignore: string;
+  protected minSearchLength = 3;
 
-  constructor(onSelect: (discussion: Discussion) => void, ignore: string) {
+  constructor(onSelect: (discussion: Discussion) => void, ignore?: (discussion: Discussion) => boolean, minSearchLength?: number) {
     this.results = new Map();
 
     this.onSelect = onSelect;
-    this.ignore = ignore;
+    this.ignore = ignore ?? (() => false);
+    this.minSearchLength = minSearchLength || this.minSearchLength;
   }
 
   search(query: string): Promise<void> {
@@ -29,7 +32,7 @@ export default class DiscussionSearchSource {
     const id = Number(query);
     const idStr = String(id);
 
-    if (!Number.isNaN(id) && idStr !== this.ignore) {
+    if (!Number.isNaN(id) && id > 0) {
       return app.store
         .find<Discussion>('discussions', idStr)
         .then((d) => {
@@ -38,11 +41,12 @@ export default class DiscussionSearchSource {
         .catch(() => {});
     }
 
+    if (query.length < this.minSearchLength) {
+      return Promise.resolve();
+    }
+
     return app.store.find<Discussion[]>('discussions', params).then((results) => {
-      this.results.set(
-        query,
-        results.filter((d) => d.id() !== this.ignore)
-      );
+      this.results.set(query, results);
     });
   }
 
@@ -51,7 +55,17 @@ export default class DiscussionSearchSource {
 
     const results = this.results.get(query) || [];
 
-    return results.map((discussion) => {
+    // Remove discussions that should be ignored (e.g. merge from/to target, discussions already selected).
+    // We do this in view instead of search to prevent issues from caching modified results.
+    const filteredResults = results.filter((discussion) => !this.ignore(discussion));
+
+    if (!filteredResults.length) {
+      return [
+        <li className="DiscussionSearchResult DiscussionSearchResult--noResults">{app.translator.trans('core.lib.search.no_results_text')}</li>,
+      ];
+    }
+
+    return filteredResults.map((discussion) => {
       const discussionId = discussion.id() || '';
       return (
         <li className="DiscussionSearchResult" data-index={'discussions' + discussionId} data-id={discussionId}>


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #12**

**Changes proposed in this pull request:**
- Allow searching for discussions with IDs <3 chars (1-99)
  - Changed min length to 1, but still require 3 for normal search (if not a number search)
- Extended ignore from discussion ID to include discussions already selected - transformed into filter function
  - Avoids confusion after clicking on result and "nothing" happens
- Add text when no results are found

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<img width="1177" height="302" alt="image" src="https://github.com/user-attachments/assets/3607c353-49fb-4198-ab0c-f5ee4f55166e" />
<img width="1171" height="244" alt="image" src="https://github.com/user-attachments/assets/20ef053c-6060-4597-971f-395f2d2f0b0e" />


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- ~~Backend changes: tests are green (run `composer test`).~~
