### PR TITLE
[2.x] style: reduce spacing in merge modal

### DIFF
--- a/js/src/forum/components/DiscussionMergeModal.tsx
+++ b/js/src/forum/components/DiscussionMergeModal.tsx
@@ -134,7 +134,7 @@ export default class DiscussionMergeModal extends FormModal<any> {
     return (
       <div className="Modal-body">
         <Form>
-          <div className="Forum-group">{this.orderItems().toArray()}</div>
+          <div className="Form-group">{this.orderItems().toArray()}</div>
           <div className="Form-group">{this.typeItems().toArray()}</div>
           <div className={classList('FormGroup', this.disabled() && 'hidden')}>
             <p className="help">
@@ -144,18 +144,22 @@ export default class DiscussionMergeModal extends FormModal<any> {
             </p>
             <DiscussionSearch state={this.searchState} onSelect={this.select.bind(this)} ignore={this.shouldIgnoreResult.bind(this)} />
           </div>
-          <div className="Form-group MergeDiscussions-Discussions">
-            <ul>
-              {this.merging.map((d) => (
-                <li>
-                  <i className="fas fa-trash DeleteEntry-Button" onclick={() => this.remove(d)} />
-                  <a href={`${app.forum.attribute('baseUrl')}/d/${d.id()}`} target="_blank">
-                    <i>{d.id()}</i>~ {d.title()}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
+
+          {!!this.merging.length && (
+            <div className="MergeDiscussions-Discussions">
+              <ul>
+                {this.merging.map((d) => (
+                  <li>
+                    <i className="fas fa-trash DeleteEntry-Button" onclick={() => this.remove(d)} />
+                    <a href={`${app.forum.attribute('baseUrl')}/d/${d.id()}`} target="_blank">
+                      <i>{d.id()}</i> ~ {d.title()}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
           <div className="Form-group MergeDiscussions-Preview">
             <Button
               className="Button Button--danger"

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -3,6 +3,7 @@
     ul {
       list-style-type: none;
       padding-left: 5px;
+      margin: 0;
     }
 
     .DeleteEntry-Button {
@@ -12,6 +13,8 @@
     }
   }
 
+  // Instead of removing the element from DOM, to avoid re-instantiating the DiscussionSearch component and
+  // losing the search state (e.g. cached results), we just hide it with CSS.
   .FormGroup.hidden {
     display: none;
     visibility: hidden;
@@ -25,6 +28,12 @@
     .Search-results {
       left: 0;
       position: relative;
+    }
+
+    .DiscussionSearchResult--noResults {
+      padding: 8px;
+      text-align: center;
+      color: var(--text-muted-color);
     }
   }
 
@@ -49,5 +58,20 @@
       overflow-y: auto;
       overflow-x: hidden;
     }
+  }
+
+  // *** Decrease overall spacing between elements in 2.x
+  h3 {
+    // Counteract extra spacing that was added in 2.x due to Form-group flex gap.
+    margin-top: 0;
+    margin-bottom: 6px;
+  }
+
+  .Form-body {
+    --gap: 18px;
+  }
+
+  .Form-group {
+    gap: 4px;
   }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->


**Changes proposed in this pull request:**
- Reduced space from flex gap between `.Form-group` items and others

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
Before -> After

<img width="600" height="471" alt="image" src="https://github.com/user-attachments/assets/3e940f81-347a-4e87-8d19-2376c3c24f12" /> <img width="600" height="382" alt="image" src="https://github.com/user-attachments/assets/4c01e072-ea3f-4022-9f21-53e288553b06" />


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- ~~Backend changes: tests are green (run `composer test`).~~
