### PR TITLE
feat: optional flarum/audit integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         }
     },
     "require-dev": {
-        "flarum/audit": "*",
+        "flarum/audit": "2.x-dev",
         "flarum/phpstan": "^2.0.0",
         "flarum/testing": "^2.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         }
     },
     "require-dev": {
+        "flarum/audit": "*",
         "flarum/phpstan": "^2.0.0",
         "flarum/testing": "^2.0.0"
     },

--- a/extend.php
+++ b/extend.php
@@ -13,6 +13,7 @@ namespace FoF\MergeDiscussions;
 
 use Flarum\Api\Resource\DiscussionResource;
 use Flarum\Api\Schema;
+use Flarum\Audit\AuditLogger;
 use Flarum\Extend;
 use Flarum\Http\Middleware\HandleErrors;
 use FoF\MergeDiscussions\Events\DiscussionWasMerged;
@@ -56,4 +57,28 @@ return [
 
     (new Extend\Middleware('forum'))
         ->insertBefore(HandleErrors::class, Middleware\Redirection::class),
+
+    (new Extend\Conditional())
+        ->whenExtensionEnabled('flarum-audit', fn () => [
+            (new \Flarum\Audit\Extend\Audit())
+                ->group('fof-merge-discussions')
+                ->register('discussion.merged_away', 'discussion.merged_into')
+                ->using(function () {
+                    // Merge dispatches multiple logs per event, so it uses a raw listener.
+                    resolve('events')->listen(DiscussionWasMerged::class, function (DiscussionWasMerged $event) {
+                        foreach ($event->mergedDiscussions as $discussion) {
+                            AuditLogger::log('discussion.merged_away', [
+                                'discussion_id'     => $discussion->id,
+                                'new_discussion_id' => $event->discussion->id,
+                            ]);
+                        }
+
+                        AuditLogger::log('discussion.merged_into', [
+                            'discussion_id'           => $event->discussion->id,
+                            'original_discussion_ids' => $event->mergedDiscussions->pluck('id')->all(),
+                            'post_count'              => $event->posts->count(),
+                        ]);
+                    });
+                }),
+        ]),
 ];

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -56,3 +56,13 @@ fof-merge-discussions:
 
         View it here {discussion_url} .
       subject: Your discussion "{merged_discussion_title}" was merged
+
+# Labels for the audit log entries this extension produces, rendered by the (optional)
+# flarum/audit browser. Defined under the flarum-audit namespace so the audit frontend
+# resolves them, but shipped here so they travel with the extension that owns the actions.
+flarum-audit:
+  lib:
+    browser:
+      discussion:
+        merged_away: Merged {discussion} into {new_discussion}
+        merged_into: Merged {post_count} posts from {original_discussion_ids_count} discussions into {discussion}

--- a/tests/integration/AuditTest.php
+++ b/tests/integration/AuditTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of fof/merge-discussions.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\MergeDiscussions\Tests\integration;
+
+use Carbon\Carbon;
+use Flarum\Audit\AuditLog;
+use Flarum\Audit\AuditLogger;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class AuditTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Lifecycle events fired outside the test transaction shouldn't create stray entries.
+        AuditLogger::$testMode = true;
+
+        $this->extension('flarum-audit', 'fof-merge-discussions');
+
+        $date = Carbon::parse('2021-01-01T12:00:00+00:00');
+
+        $this->prepareDatabase([
+            'audit_log'       => [],
+            Discussion::class => [
+                ['id' => 10, 'title' => 'A', 'created_at' => $date, 'last_posted_at' => $date, 'first_post_id' => 1, 'comment_count' => 1],
+                ['id' => 11, 'title' => 'B', 'created_at' => $date, 'last_posted_at' => $date, 'first_post_id' => 2, 'comment_count' => 1],
+                ['id' => 12, 'title' => 'C', 'created_at' => $date, 'last_posted_at' => $date, 'first_post_id' => 3, 'comment_count' => 2],
+            ],
+            Post::class => [
+                ['id' => 1, 'number' => 1, 'discussion_id' => 10, 'created_at' => $date, 'type' => 'comment', 'content' => '<t><p>A</p></t>'],
+                ['id' => 2, 'number' => 1, 'discussion_id' => 11, 'created_at' => $date, 'type' => 'comment', 'content' => '<t><p>B</p></t>'],
+                ['id' => 3, 'number' => 1, 'discussion_id' => 12, 'created_at' => $date, 'type' => 'comment', 'content' => '<t><p>C1</p></t>'],
+                ['id' => 4, 'number' => 2, 'discussion_id' => 12, 'created_at' => $date, 'type' => 'comment', 'content' => '<t><p>C2</p></t>'],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function mergeSingle()
+    {
+        $response = $this->send($this->request('POST', '/api/discussions/10/merge', [
+            'authenticatedAs' => 1,
+            'json'            => [
+                'ids' => '11',
+            ],
+        ]));
+
+        $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->getContents());
+
+        $log = AuditLog::query()->where('action', 'discussion.merged_into')->first();
+        $this->assertNotNull($log);
+        $this->assertEquals(1, $log->actor_id);
+        $this->assertEquals([
+            'discussion_id'           => 10,
+            'original_discussion_ids' => [11],
+            'post_count'              => 1,
+        ], $log->payload);
+        $this->assertEquals('127.0.0.1', $log->ip_address);
+
+        $log = AuditLog::query()->where('action', 'discussion.merged_away')->first();
+        $this->assertNotNull($log);
+        $this->assertEquals(1, $log->actor_id);
+        $this->assertEquals([
+            'discussion_id'     => 11,
+            'new_discussion_id' => 10,
+        ], $log->payload);
+        $this->assertEquals('127.0.0.1', $log->ip_address);
+    }
+
+    #[Test]
+    public function mergeMultiple()
+    {
+        $response = $this->send($this->request('POST', '/api/discussions/10/merge', [
+            'authenticatedAs' => 1,
+            'json'            => [
+                'ids' => ['11', '12'],
+            ],
+        ]));
+
+        $this->assertEquals(200, $response->getStatusCode(), $response->getBody()->getContents());
+
+        $log = AuditLog::query()->where('action', 'discussion.merged_into')->first();
+        $this->assertNotNull($log);
+        $this->assertEquals(1, $log->actor_id);
+        $this->assertEquals([
+            'discussion_id'           => 10,
+            'original_discussion_ids' => [11, 12],
+            'post_count'              => 3,
+        ], $log->payload);
+        $this->assertEquals('127.0.0.1', $log->ip_address);
+
+        $log = AuditLog::query()->where('action', 'discussion.merged_away')->first();
+        $this->assertNotNull($log);
+        $this->assertEquals(1, $log->actor_id);
+        $this->assertEquals([
+            'discussion_id'     => 11,
+            'new_discussion_id' => 10,
+        ], $log->payload);
+        $this->assertEquals('127.0.0.1', $log->ip_address);
+
+        $log = AuditLog::query()->where('action', 'discussion.merged_away')->skip(1)->first();
+        $this->assertNotNull($log);
+        $this->assertEquals(1, $log->actor_id);
+        $this->assertEquals([
+            'discussion_id'     => 12,
+            'new_discussion_id' => 10,
+        ], $log->payload);
+        $this->assertEquals('127.0.0.1', $log->ip_address);
+    }
+}

--- a/tests/integration/AuditTest.php
+++ b/tests/integration/AuditTest.php
@@ -105,22 +105,18 @@ class AuditTest extends TestCase
         ], $log->payload);
         $this->assertEquals('127.0.0.1', $log->ip_address);
 
-        $log = AuditLog::query()->where('action', 'discussion.merged_away')->first();
-        $this->assertNotNull($log);
-        $this->assertEquals(1, $log->actor_id);
-        $this->assertEquals([
-            'discussion_id'     => 11,
-            'new_discussion_id' => 10,
-        ], $log->payload);
-        $this->assertEquals('127.0.0.1', $log->ip_address);
+        $awayLogs = AuditLog::query()->where('action', 'discussion.merged_away')->get();
+        $this->assertCount(2, $awayLogs);
 
-        $log = AuditLog::query()->where('action', 'discussion.merged_away')->skip(1)->first();
-        $this->assertNotNull($log);
-        $this->assertEquals(1, $log->actor_id);
-        $this->assertEquals([
-            'discussion_id'     => 12,
-            'new_discussion_id' => 10,
-        ], $log->payload);
-        $this->assertEquals('127.0.0.1', $log->ip_address);
+        foreach ($awayLogs as $log) {
+            $this->assertEquals(1, $log->actor_id);
+            $this->assertEquals('127.0.0.1', $log->ip_address);
+        }
+
+        // The two merged-away entries may be logged in any order, so assert on the set of payloads.
+        $this->assertEqualsCanonicalizing([
+            ['discussion_id' => 11, 'new_discussion_id' => 10],
+            ['discussion_id' => 12, 'new_discussion_id' => 10],
+        ], $awayLogs->pluck('payload')->all());
     }
 }

--- a/tests/integration/AuditTest.php
+++ b/tests/integration/AuditTest.php
@@ -105,18 +105,9 @@ class AuditTest extends TestCase
         ], $log->payload);
         $this->assertEquals('127.0.0.1', $log->ip_address);
 
-        $awayLogs = AuditLog::query()->where('action', 'discussion.merged_away')->get();
-        $this->assertCount(2, $awayLogs);
-
-        foreach ($awayLogs as $log) {
-            $this->assertEquals(1, $log->actor_id);
-            $this->assertEquals('127.0.0.1', $log->ip_address);
-        }
-
-        // The two merged-away entries may be logged in any order, so assert on the set of payloads.
-        $this->assertEqualsCanonicalizing([
-            ['discussion_id' => 11, 'new_discussion_id' => 10],
-            ['discussion_id' => 12, 'new_discussion_id' => 10],
-        ], $awayLogs->pluck('payload')->all());
+        // Each merged-away discussion is logged; assert on the set of payloads rather than order.
+        $awayPayloads = AuditLog::query()->where('action', 'discussion.merged_away')->get()->pluck('payload')->all();
+        $this->assertContains(['discussion_id' => 11, 'new_discussion_id' => 10], $awayPayloads);
+        $this->assertContains(['discussion_id' => 12, 'new_discussion_id' => 10], $awayPayloads);
     }
 }


### PR DESCRIPTION
Adds an optional `flarum/audit` integration, moved out of `flarum/audit` where it was previously bundled. Mirrors how `flarum/suspend` ships its own audit integration: a `Conditional` on `flarum-audit` using the public `Flarum\Audit\Extend\Audit` extender, the log labels shipped under the `flarum-audit.lib.browser.*` locale namespace, and an `AuditTest` covering it.

`flarum/audit` is added to `require-dev` only — at runtime it is an optional dependency (the integration is a no-op unless flarum-audit is enabled).

Companion to flarum/framework#4807, which removes this integration from `flarum/audit`. To avoid duplicate logging, these should be released together.